### PR TITLE
[FEAT] #93 이미지 슬라이드 구현 in 관리자 페이지와 매물 상세 페이지

### DIFF
--- a/src/components/admin/AdminListItemCard.vue
+++ b/src/components/admin/AdminListItemCard.vue
@@ -20,32 +20,38 @@
       </div>
     </div>
 
-    <div class="flex justify-between gap-1 items-center">
+    <div class="flex justify-between gap-2 items-start md:items-center">
       <!-- 왼쪽 텍스트 -->
-      <div class="flex flex-col justify-between flex-1 mr-4">
-        <div>
-          <!-- 주소 -->
-          <BaseTypography size="xs" weight="regular" color="gray-2" class="mt-0.5">
-            {{ address }}
+      <div class="flex flex-col justify-between flex-1 w-0 mr-2">
+        <!-- 주소 (한 줄, ... 처리) -->
+        <BaseTypography
+          size="xs"
+          weight="regular"
+          color="gray-2"
+          class="truncate whitespace-nowrap overflow-hidden w-full"
+          :title="address"
+        >
+          {{ address }}
+        </BaseTypography>
+
+        <!-- 희망 매각가 -->
+        <div class="flex items-center mt-2">
+          <BaseTypography size="xs" weight="regular" color="gray-2" class="min-w-[90px]">
+            희망 매각가
           </BaseTypography>
+          <BaseTypography weight="bold" color="black" class="whitespace-nowrap">
+            {{ formattedPrice }}
+          </BaseTypography>
+        </div>
 
-          <!-- 희망 매각가 -->
-          <div class="flex items-center gap-2 mt-2">
-            <BaseTypography size="xs" weight="regular" color="gray-2" class="min-w-[90px]">
-              희망 매각가
-            </BaseTypography>
-            <BaseTypography weight="bold" color="black">
-              {{ formattedPrice }}
-            </BaseTypography>
-          </div>
-
-          <!-- 희망 공모 기간 -->
-          <div class="flex items-center gap-2 mt-1">
-            <BaseTypography size="xs" weight="regular" color="gray-2" class="min-w-[90px]">
-              희망 공모 기간
-            </BaseTypography>
-            <BaseTypography weight="bold" color="black"> {{ postingPeriod }}개월 </BaseTypography>
-          </div>
+        <!-- 희망 공모 기간 -->
+        <div class="flex items-center mt-1">
+          <BaseTypography size="xs" weight="regular" color="gray-2" class="min-w-[90px]">
+            희망 공모 기간
+          </BaseTypography>
+          <BaseTypography weight="bold" color="black" class="whitespace-nowrap">
+            {{ postingPeriod }}개월
+          </BaseTypography>
         </div>
       </div>
 
@@ -53,7 +59,7 @@
       <img
         :src="image || fallbackImage"
         alt="매물 이미지"
-        class="w-40 h-20 object-cover rounded-md self-end mr-2"
+        class="max-w-[160px] h-20 object-cover rounded-md md:self-end"
       />
     </div>
 

--- a/src/pages/admin/AdminDetailPage.vue
+++ b/src/pages/admin/AdminDetailPage.vue
@@ -1,119 +1,152 @@
 <template>
-  <div class="p-6 space-y-4" v-if="property">
-    <div class="flex justify-between items-start">
-      <div class="flex justify-between items-center gap-4">
-        <span class="material-symbols-outlined text-2xl cursor-pointer" @click="goBack">
-          chevron_left
-        </span>
-        <BaseTypography size="xl" weight="bold">{{ property.title }}</BaseTypography>
+  <BlankLayout>
+    <div v-if="property">
+      <div class="flex justify-between items-start">
+        <DetailHeader size="xl" weight="bold">{{ property.title }}</DetailHeader>
       </div>
-      <BaseTypography class="self-end" size="sm" color="gray-2"
-        >등록일: {{ formatDateTime(property.updatedAt) }}
-      </BaseTypography>
-    </div>
 
-    <section class="border p-4 rounded-lg bg-white">
-      <BaseTypography class="mb-2" weight="semibold" size="lg">매도자 정보</BaseTypography>
-      <BaseTypography weight="regular">이름: {{ property.seller.name }}</BaseTypography>
-      <BaseTypography weight="regular">전화번호: {{ property.seller.phone }}</BaseTypography>
-      <BaseTypography weight="regular">이메일: {{ property.seller.email }}</BaseTypography>
-    </section>
+      <section class="bg-white px-2">
+        <BaseTypography class="self-end" size="sm" color="gray-2">
+          등록일: {{ formatDateTime(property.updatedAt) }}
+        </BaseTypography>
+      </section>
 
-    <section class="border p-4 rounded-lg bg-white">
-      <BaseTypography class="mb-2" weight="semibold" size="lg">매물 정보</BaseTypography>
-      <BaseTypography weight="regular">매물명: {{ property.title }}</BaseTypography>
-      <BaseTypography weight="regular">매물 주소: {{ property.address }}</BaseTypography>
-      <BaseTypography weight="regular"
-        >매물 면적: {{ property.area }}㎡({{ formatAreaToPyeong(property.area) }})
-      </BaseTypography>
-      <BaseTypography weight="regular"
-        >희망 매매가: {{ formatPriceInManwon(property.price) }}
-      </BaseTypography>
-      <BaseTypography weight="regular"
-        >희망 공모 기간: {{ property.postingPeriod }}개월
-      </BaseTypography>
-    </section>
+      <section class="border p-4 rounded-lg bg-white mt-1">
+        <BaseTypography class="mb-2" weight="semibold" size="lg">매도자 정보</BaseTypography>
+        <BaseTypography weight="regular">이름: {{ property.seller.name }}</BaseTypography>
+        <BaseTypography weight="regular">전화번호: {{ property.seller.phone }}</BaseTypography>
+        <BaseTypography weight="regular">이메일: {{ property.seller.email }}</BaseTypography>
+      </section>
 
-    <section class="border p-4 rounded-lg bg-white">
-      <BaseTypography class="mb-2" weight="semibold" size="lg"
-        >매물의 건축물 대장 정보</BaseTypography
-      >
-      <BaseTypography weight="regular">용도지역: {{ property.usageDistrict }}</BaseTypography>
-      <BaseTypography weight="regular">
-        대지 면적(매물): {{ property.landArea }}㎡({{ formatAreaToPyeong(property.landArea) }})
-      </BaseTypography>
-      <BaseTypography weight="regular">
-        대지 면적(건물): {{ property.buildingArea }}㎡({{
-          formatAreaToPyeong(property.buildingArea)
-        }})
-      </BaseTypography>
-      <BaseTypography weight="regular">
-        연면적(매물): {{ property.totalFloorAreaProperty }}㎡({{
-          formatAreaToPyeong(property.totalFloorAreaProperty)
-        }})
-      </BaseTypography>
-      <BaseTypography weight="regular">
-        연면적(건물): {{ property.totalFloorAreaBuilding }}㎡({{
-          formatAreaToPyeong(property.totalFloorAreaBuilding)
-        }})
-      </BaseTypography>
-      <BaseTypography weight="regular"
-        >건물 규모: 지하 {{ property.basementFloors }}층 / 지상
-        {{ property.groundFloors }}층</BaseTypography
-      >
-      <BaseTypography weight="regular"
-        >준공일: {{ formatDateTime(property.createdAt) }}</BaseTypography
-      >
-      <BaseTypography weight="regular"
-        >공시지가: {{ formatPriceInManwon(property.officialLandPrice) }}</BaseTypography
-      >
-      <BaseTypography weight="regular"
-        >연면적 평단가(평/공모금액 기준):
-        {{ formatPriceInManwon(property.unitPricePerPyeong) }}</BaseTypography
-      >
-    </section>
+      <section class="border p-4 rounded-lg bg-white mt-4">
+        <BaseTypography class="mb-2" weight="semibold" size="lg">매물 정보</BaseTypography>
+        <BaseTypography weight="regular">매물명: {{ property.title }}</BaseTypography>
+        <BaseTypography weight="regular">매물 주소: {{ property.address }}</BaseTypography>
+        <BaseTypography weight="regular"
+          >매물 면적: {{ property.area }}㎡({{ formatAreaToPyeong(property.area) }})
+        </BaseTypography>
+        <BaseTypography weight="regular"
+          >희망 매매가: {{ formatPriceInManwon(property.price) }}
+        </BaseTypography>
+        <BaseTypography weight="regular"
+          >희망 공모 기간: {{ property.postingPeriod }}개월
+        </BaseTypography>
+      </section>
 
-    <section class="border p-4 rounded-lg bg-white">
-      <BaseTypography class="mb-2" weight="semibold" size="lg">매물 상세 정보</BaseTypography>
-      <BaseTypography weight="regular">방 수: {{ property.roomCount }}개</BaseTypography>
-      <BaseTypography weight="regular">욕실 수: {{ property.bathroomCount }}개</BaseTypography>
-      <BaseTypography weight="regular">해당 층 수: {{ property.floor }}층</BaseTypography>
-      <BaseTypography weight="regular">해시 태그: #역세권 #신축</BaseTypography>
-      <BaseTypography weight="regular">세부 정보: {{ property.description }}</BaseTypography>
-      <BaseTypography weight="regular">
+      <section class="border p-4 rounded-lg bg-white mt-4">
+        <BaseTypography class="mb-2" weight="semibold" size="lg"
+          >매물의 건축물 대장 정보</BaseTypography
+        >
+        <BaseTypography weight="regular">용도지역: {{ property.usageDistrict }}</BaseTypography>
+        <BaseTypography weight="regular">
+          대지 면적(매물): {{ property.landArea }}㎡({{ formatAreaToPyeong(property.landArea) }})
+        </BaseTypography>
+        <BaseTypography weight="regular">
+          대지 면적(건물): {{ property.buildingArea }}㎡({{
+            formatAreaToPyeong(property.buildingArea)
+          }})
+        </BaseTypography>
+        <BaseTypography weight="regular">
+          연면적(매물): {{ property.totalFloorAreaProperty }}㎡({{
+            formatAreaToPyeong(property.totalFloorAreaProperty)
+          }})
+        </BaseTypography>
+        <BaseTypography weight="regular">
+          연면적(건물): {{ property.totalFloorAreaBuilding }}㎡({{
+            formatAreaToPyeong(property.totalFloorAreaBuilding)
+          }})
+        </BaseTypography>
+        <BaseTypography weight="regular"
+          >건물 규모: 지하 {{ property.basementFloors }}층 / 지상
+          {{ property.groundFloors }}층</BaseTypography
+        >
+        <BaseTypography weight="regular"
+          >준공일: {{ formatDateTime(property.createdAt) }}</BaseTypography
+        >
+        <BaseTypography weight="regular"
+          >공시지가: {{ formatPriceInManwon(property.officialLandPrice) }}</BaseTypography
+        >
+        <BaseTypography weight="regular"
+          >연면적 평단가(평/공모금액 기준):
+          {{ formatPriceInManwon(property.unitPricePerPyeong) }}</BaseTypography
+        >
+      </section>
+
+      <section class="border p-4 rounded-lg bg-white mt-4">
+        <BaseTypography class="mb-2" weight="semibold" size="lg">매물 상세 정보</BaseTypography>
+        <BaseTypography weight="regular">방 수: {{ property.roomCount }}개</BaseTypography>
+        <BaseTypography weight="regular">욕실 수: {{ property.bathroomCount }}개</BaseTypography>
+        <BaseTypography weight="regular">해당 층 수: {{ property.floor }}층</BaseTypography>
+        <BaseTypography weight="regular">해시 태그: #역세권 #신축</BaseTypography>
+        <BaseTypography weight="regular">세부 정보: {{ property.description }}</BaseTypography>
+        <!-- <BaseTypography weight="regular">
         이미지:
         <img
           :src="property.thumbnail.photoUrl"
           class="w-full max-w-sm border rounded-md"
           alt="대표 이미지"
         />
-      </BaseTypography>
-    </section>
+      </BaseTypography> -->
 
-    <section class="border p-4 rounded-lg bg-white">
-      <BaseTypography class="mb-2" weight="semibold" size="lg">매물 서류</BaseTypography>
-      <ul>
-        <li v-for="doc in property.documents" :key="doc.fileUrl">
-          <a
-            :href="doc.fileUrl"
-            class="text-blue-500 underline"
-            target="_blank"
-            :download="getDocumentName(doc.documentType)"
-          >
-            {{ getDocumentName(doc.documentType) }}
-          </a>
-        </li>
-      </ul>
-    </section>
-  </div>
+        <BaseTypography weight="regular">
+          이미지:
+          <div class="relative w-full max-w-sm h-60 mt-2">
+            <!-- 이미지 -->
+            <img
+              :src="property.images[currentImageIndex].photoUrl"
+              class="w-full h-full object-contain border rounded-md mx-auto"
+              alt="매물 이미지"
+            />
+
+            <!-- 좌우 터치 영역 -->
+            <div class="absolute left-0 top-0 w-1/2 h-full cursor-pointer" @click="prevImage"></div>
+            <div
+              class="absolute right-0 top-0 w-1/2 h-full cursor-pointer"
+              @click="nextImage"
+            ></div>
+
+            <!-- 좌우 아이콘 (희미하게 보이도록) -->
+            <span
+              class="absolute left-2 top-1/2 -translate-y-1/2 material-symbols-outlined text-3xl text-black/30 pointer-events-none select-none"
+            >
+              chevron_left
+            </span>
+            <span
+              class="absolute right-2 top-1/2 -translate-y-1/2 material-symbols-outlined text-3xl text-black/30 pointer-events-none select-none"
+            >
+              chevron_right
+            </span>
+          </div>
+        </BaseTypography>
+      </section>
+
+      <section class="border p-4 rounded-lg bg-white mt-4 mb-16">
+        <BaseTypography class="mb-2" weight="semibold" size="lg">매물 서류</BaseTypography>
+        <ul>
+          <li v-for="doc in property.documents" :key="doc.fileUrl">
+            <a
+              :href="doc.fileUrl"
+              class="text-blue-500 underline"
+              target="_blank"
+              :download="getDocumentName(doc.documentType)"
+            >
+              {{ getDocumentName(doc.documentType) }}
+            </a>
+          </li>
+        </ul>
+      </section>
+    </div>
+  </BlankLayout>
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { usePropertyAdmin } from '@/stores/propertyadmin'
 import { formatDateTime, formatPriceInManwon, formatAreaToPyeong } from '@/utils/format'
 import BaseTypography from '@/components/common/Typography/BaseTypography.vue'
+import BlankLayout from '@/layouts/BlankLayout.vue'
+import DetailHeader from '@/layouts/DetailHeader.vue'
 
 const router = useRouter()
 
@@ -125,7 +158,34 @@ const route = useRoute()
 const propertyId = computed(() => Number(route.params.id))
 const { propertyList } = usePropertyAdmin()
 
-const property = computed(() => propertyList.find((p) => p.id === propertyId.value))
+// current image index
+const currentImageIndex = ref(0)
+function prevImage() {
+  currentImageIndex.value =
+    (currentImageIndex.value - 1 + property.value.images.length) % property.value.images.length
+}
+function nextImage() {
+  currentImageIndex.value = (currentImageIndex.value + 1) % property.value.images.length
+}
+
+// property + 이미지 mock 삽입
+const property = computed(() => {
+  const original = propertyList.find((p) => p.id === propertyId.value)
+  if (!original) return null
+
+  const mockImages = [
+    '/src/assets/images/cardtestimage.png',
+    '/src/assets/images/sample-buliding.png',
+    '/src/assets/images/mockup.png',
+    '/src/assets/images/logo.png',
+    '/src/assets/images/DeleteUser.png',
+  ]
+
+  return {
+    ...original,
+    images: mockImages.map((url) => ({ photoUrl: url })),
+  }
+})
 
 function getDocumentName(type) {
   switch (type) {

--- a/src/pages/funding/FundingDetailPage.vue
+++ b/src/pages/funding/FundingDetailPage.vue
@@ -1,55 +1,3 @@
-<script setup>
-import { ref, computed } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
-
-import BaseTab from '@/components/common/Tab/BaseTab.vue'
-import BaseTypography from '@/components/common/Typography/BaseTypography.vue'
-import DetailHeader from '@/layouts/DetailHeader.vue'
-import FundingBuildingInfo from '@/components/funding/detail/FundingBuildingInfo.vue'
-import FundingInvestmentInfo from '@/components/funding/detail/FundingInvestmentInfo.vue'
-import FundingFundingInfo from '@/components/funding/detail/FundingFundingInfo.vue'
-
-import { format, formatDate, formatPriceInEokwon, dDay } from '@/utils/format'
-import { mockItems } from './mockData'
-
-const router = useRouter()
-const route = useRoute()
-
-const tabs = [
-  { label: '건물 정보', value: 'building' },
-  { label: '투자 정보', value: 'investment' },
-  { label: '펀딩 정보', value: 'funding' },
-]
-
-const currentTab = ref('building')
-const itemId = Number(route.params.id)
-const item = mockItems.find((f) => f.propertyId === itemId) || {}
-
-const tabComponent = computed(() => {
-  switch (currentTab.value) {
-    case 'building':
-      return FundingBuildingInfo
-    case 'investment':
-      return FundingInvestmentInfo
-    case 'funding':
-      return FundingFundingInfo
-    default:
-      return FundingBuildingInfo
-  }
-})
-
-const goToTradePage = () => {
-  const id = item.propertyId
-  if (item.status === 'PENDING') {
-    router.push(`/trade/${id}`)
-  } else if (item.status === 'FUNDING') {
-    router.push(`/funding/trade/${id}`)
-  } else {
-    alert('현재 거래 가능한 상태가 아닙니다.')
-  }
-}
-</script>
-
 <template>
   <div class="flex flex-col min-h-screen bg-gray-50">
     <!-- 헤더 -->
@@ -60,7 +8,29 @@ const goToTradePage = () => {
     <!-- 콘텐츠 영역 -->
     <div class="flex-1 overflow-y-auto">
       <!-- 썸네일 -->
-      <img :src="item.thumbnail?.photoUrl" class="w-full h-[180px] object-cover" alt="thumbnail" />
+      <div class="relative w-full h-[180px] bg-gray-100">
+        <img
+          :src="item.images[currentImageIndex].photoUrl"
+          class="w-full h-full object-contain"
+          alt="매물 이미지"
+        />
+
+        <!-- 좌우 터치 영역 -->
+        <div class="absolute left-0 top-0 w-1/2 h-full cursor-pointer" @click="prevImage"></div>
+        <div class="absolute right-0 top-0 w-1/2 h-full cursor-pointer" @click="nextImage"></div>
+
+        <!-- 좌우 아이콘 -->
+        <span
+          class="absolute left-2 top-1/2 -translate-y-1/2 material-symbols-outlined text-3xl text-black/30 pointer-events-none select-none"
+        >
+          chevron_left
+        </span>
+        <span
+          class="absolute right-2 top-1/2 -translate-y-1/2 material-symbols-outlined text-3xl text-black/30 pointer-events-none select-none"
+        >
+          chevron_right
+        </span>
+      </div>
 
       <!-- 제목 + 주소 -->
       <div class="px-4 pt-3">
@@ -153,3 +123,70 @@ const goToTradePage = () => {
     </div>
   </div>
 </template>
+
+<script setup>
+import { ref, computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
+import BaseTab from '@/components/common/Tab/BaseTab.vue'
+import BaseTypography from '@/components/common/Typography/BaseTypography.vue'
+import DetailHeader from '@/layouts/DetailHeader.vue'
+import FundingBuildingInfo from '@/components/funding/detail/FundingBuildingInfo.vue'
+import FundingInvestmentInfo from '@/components/funding/detail/FundingInvestmentInfo.vue'
+import FundingFundingInfo from '@/components/funding/detail/FundingFundingInfo.vue'
+
+import { format, formatDate, formatPriceInEokwon, dDay } from '@/utils/format'
+import { mockItems } from './mockData'
+
+const router = useRouter()
+const route = useRoute()
+
+const tabs = [
+  { label: '건물 정보', value: 'building' },
+  { label: '투자 정보', value: 'investment' },
+  { label: '펀딩 정보', value: 'funding' },
+]
+
+const currentTab = ref('building')
+const itemId = Number(route.params.id)
+const item = mockItems.find((f) => f.propertyId === itemId) || {}
+
+const tabComponent = computed(() => {
+  switch (currentTab.value) {
+    case 'building':
+      return FundingBuildingInfo
+    case 'investment':
+      return FundingInvestmentInfo
+    case 'funding':
+      return FundingFundingInfo
+    default:
+      return FundingBuildingInfo
+  }
+})
+
+const goToTradePage = () => {
+  const id = item.propertyId
+  if (item.status === 'PENDING') {
+    router.push(`/trade/${id}`)
+  } else if (item.status === 'FUNDING') {
+    router.push(`/funding/trade/${id}`)
+  } else {
+    alert('현재 거래 가능한 상태가 아닙니다.')
+  }
+}
+
+const currentImageIndex = ref(0)
+
+function prevImage() {
+  currentImageIndex.value = (currentImageIndex.value - 1 + item.images.length) % item.images.length
+}
+function nextImage() {
+  currentImageIndex.value = (currentImageIndex.value + 1) % item.images.length
+}
+
+item.images = item.images || [
+  { photoUrl: '/src/assets/images/cardtestimage.png' },
+  { photoUrl: '/src/assets/images/sample-buliding.png' },
+  { photoUrl: '/src/assets/images/mockup.png' },
+]
+</script>


### PR DESCRIPTION
---
name: ✨ PR 템플릿
about: 새로운 기능 구현 및 추가를 위한 PR 템플릿입니다.
---
## 🔖 PR 유형
- [x] ✨ 기능 추가
- [x] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
관리자 페이지와 매물 상세 페이지에 이미지 슬라이드를 구현합니다.
관리자 페이지 UI 수정 (모바일에 맞게)

## 🔧 작업 내용
<img width="435" height="779" alt="image" src="https://github.com/user-attachments/assets/b964c1cd-b3f4-4b03-8274-aaf02e99da38" />
<img width="368" height="281" alt="image" src="https://github.com/user-attachments/assets/58214c5d-c6ef-441a-a950-ce502751206f" />

## ✅ 체크리스트
- [ ] 테스트 완료(Postman, Swagger)

## 📝 기타 참고 사항


## 📎 관련 이슈
Close #93 
