### PR TITLE
[FIX] #196 Fix missing points data after login

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -25,6 +25,8 @@ onMounted(async () => {
     await authStore.loadUserInfo()
     if (authStore.getIsLoggedIn) {
       notificationStore.fetch()
+      const point = await getPointBalance(authStore.userId)
+      authStore.setUserPoint(point)
     }
   } else {
     authStore.logout()

--- a/src/components/main/PointSection/LoggedInStatus/LoggedInPointSection.vue
+++ b/src/components/main/PointSection/LoggedInStatus/LoggedInPointSection.vue
@@ -33,7 +33,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useAuthStore } from '@/stores/authStore'
 import { useToastStore } from '@/stores/toast'
@@ -71,6 +71,15 @@ onMounted(async () => {
     authStore.setUserPoint(point)
   } catch (e) {
     console.error('포인트 불러오기 실패:', e)
+  }
+  if (getIsLoggedIn.value) {
+    await refreshPointBalance()
+  }
+})
+
+watch(getIsLoggedIn, async (loggedIn) => {
+  if (loggedIn) {
+    await refreshPointBalance()
   }
 })
 


### PR DESCRIPTION
## 🔖 PR 유형
- [ ] ✨ 기능 추가
- [x] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
로그인 직후 사용자 포인트 데이터가 화면에 표시되지 않는 버그를 수정

## 🔧 작업 내용
App.vue와 LoggedInPointSection.vue에서 로그인 시점에 포인트 데이터를 정상적으로 불러오도록 로직 수정

## ✅ 체크리스트
- [ ] 테스트 완료(Postman, Swagger)

## 📝 기타 참고 사항

## 📎 관련 이슈
Close #196
