### PR TITLE
[QA] #230 호가 차트 페이지 - 주문 구매시 현재가 기반으로 값 변동이 이루어지게 하기

### DIFF
--- a/src/components/trade/BuyAndSell/TradeForm.vue
+++ b/src/components/trade/BuyAndSell/TradeForm.vue
@@ -9,6 +9,7 @@
           placeholder="0"
           class="flex-1 bg-transparent outline-none text-black text-lg min-w-0"
           min="0"
+          @input="userTouched = true"
         />
         <div class="flex items-center gap-x-1 ml-2 shrink-0">
           <BaseTypography weight="medium" class="text-black text-lg">원</BaseTypography>
@@ -43,6 +44,7 @@
           placeholder="0"
           class="flex-1 bg-transparent outline-none text-black text-lg min-w-0"
           min="0"
+          @input="userTouched = false"
         />
         <div class="flex items-center gap-x-1 ml-2 shrink-0">
           <BaseTypography weight="medium" class="text-black text-lg">주</BaseTypography>
@@ -101,7 +103,7 @@
 </template>
 
 <script setup>
-import { ref, computed, defineProps } from 'vue'
+import { ref, computed, defineProps, watch, onMounted } from 'vue'
 import CompletedButton from '@/components/common/Button/CompletedButton.vue'
 import BaseTypography from '@/components/common/Typography/BaseTypography.vue'
 import TradeConfirmModal from './Modal/TradeConfirmModal.vue'
@@ -110,6 +112,8 @@ import { useAuthStore } from '@/stores/authStore'
 const props = defineProps({
   type: { type: String, default: 'buy' },
   fundingId: { type: Number, required: true },
+  isOpen: { type: Boolean, default: false },
+  initialPrice: { type: Number, default: 0 },
 })
 
 const authStore = useAuthStore()
@@ -119,16 +123,32 @@ const amount = ref(0)
 const quantity = ref(0)
 const isConfirmOpen = ref(false)
 
+onMounted(() => {
+  if (props.type === 'buy' && props.initialPrice > 0) {
+    amount.value = props.initialPrice
+  }
+})
+
+watch(
+  () => props.type,
+  (newType, oldType) => {
+    if (!props.isOpen || newType === oldType) return
+    if (newType === 'buy') {
+      amount.value = props.initialPrice || 0
+    } else {
+      amount.value = props.initialPrice || 0
+      quantity.value = 0
+    }
+  },
+)
+
 const incrementAmount = () => (amount.value += 10)
 const decrementAmount = () => (amount.value = Math.max(0, amount.value - 10))
 const incrementQuantity = () => (quantity.value += 1)
 const decrementQuantity = () => (quantity.value = Math.max(0, quantity.value - 1))
 
 const emit = defineEmits(['completed'])
-
-const handleTradeCompleted = () => {
-  emit('completed')
-}
+const handleTradeCompleted = () => emit('completed')
 
 const openConfirmModal = () => {
   if (!isLoggedIn.value) return


### PR DESCRIPTION
---
name: ✨ PR 템플릿
about: 새로운 기능 구현 및 추가를 위한 PR 템플릿입니다.
---
## 🔖 PR 유형
- [ ] ✨ 기능 추가
- [x] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요


## 🔧 작업 내용
1. 구매창 진입 시, 희망 구매 금액 기본값을 현재가로 자동 세팅
2. 현재가 변동 후 구매창 재진입 시 최신 값으로 반영
3. 사용자가 직접 금액을 변경할 수 있도록 기존 입력 가능 기능은 유지

## ✅ 체크리스트
- [ ] 테스트 완료(Postman, Swagger)

## 📝 기타 참고 사항


## 📎 관련 이슈
Close #230 
