### PR TITLE
[FIX] #307 거래 리스트 페이지 무한 스크롤 이슈 해결

### DIFF
--- a/src/pages/trade/TradeListPage.vue
+++ b/src/pages/trade/TradeListPage.vue
@@ -1,15 +1,17 @@
 <template>
   <BlankLayout>
-    <DetailHeader>거래중인 건물</DetailHeader>
+    <div class="flex flex-col h-[calc(100vh-3rem)]">
+      <DetailHeader>거래중인 건물</DetailHeader>
 
-    <div ref="scrollContainerRef" class="flex-1 overflow-y-auto pb-24">
-      <TradingListCard :items="tradeItems" />
-      <div ref="bottomRef" class="h-2" />
-      <div v-if="isLoading" class="flex justify-center py-4">
-        <img
-          src="@/assets/images/character/loading.png"
-          class="w-12 h-12 animate-spin opacity-70"
-        />
+      <div ref="scrollContainerRef" class="flex-1 overflow-y-auto pb-24 scrollbar-none">
+        <TradingListCard :items="tradeItems" />
+        <div ref="bottomRef" class="h-2" />
+        <div v-if="isLoading" class="flex justify-center py-4">
+          <img
+            src="@/assets/images/character/loading.png"
+            class="w-12 h-12 animate-spin opacity-70"
+          />
+        </div>
       </div>
     </div>
   </BlankLayout>


### PR DESCRIPTION
## 🔖 PR 유형
- [ ] ✨ 기능 추가
- [x] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
거래 리스트 페이지에서 무한 스크롤이 적용되지 않는 오류 해결

## 🔧 작업 내용
<div ref="scrollContainerRef"> 에 높이(flex-1 + 부모 height) 및 scrollbar-none 클래스 추가
→ 스크롤 컨테이너가 실제 스크롤 영역을 갖도록 보장하고, 브라우저 기본 스크롤바를 숨기기 위해 수정
기존 IntersectionObserver, fetch 로직 등은 변경하지 않음

## ✅ 체크리스트
- [ ] 테스트 완료(Postman, Swagger)

## 📝 기타 참고 사항

## 📎 관련 이슈
Close #307 
